### PR TITLE
Proposal: Tighten types

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,15 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -2,8 +2,8 @@ name = "FDM"
 uuid = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
 
 [deps]
-Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -3,7 +3,7 @@
 
 Approximate the gradient of `f` at `x` using `fdm`. Assumes that `f(x)` is scalar.
 """
-function grad(fdm, f, x::Array{T}) where T<:Real
+function grad(fdm, f, x::Vector{T}) where T<:Real
     v, dx, tmp = fill(zero(T), size(x)), similar(x), similar(x)
     for n in eachindex(x)
         v[n] = one(T)

--- a/src/grad.jl
+++ b/src/grad.jl
@@ -3,7 +3,7 @@
 
 Approximate the gradient of `f` at `x` using `fdm`. Assumes that `f(x)` is scalar.
 """
-function grad(fdm, f, x::AbstractArray{T}) where T<:Real
+function grad(fdm, f, x::Array{T}) where T<:Real
     v, dx, tmp = fill(zero(T), size(x)), similar(x), similar(x)
     for n in eachindex(x)
         v[n] = one(T)
@@ -25,25 +25,25 @@ end
 Approximate the Jacobian of `f` at `x` using `fdm`. `f(x)` must be a length `D` vector. If
 `D` is not provided, then `f(x)` is computed once to determine the output size.
 """
-function jacobian(fdm, f, x::AV{T}, D::Int) where {T<:Real}
+function jacobian(fdm, f, x::Vector{T}, D::Int) where {T<:Real}
     J = Matrix{T}(undef, D, length(x))
     for d in 1:D
         J[d, :] = grad(fdm, x->f(x)[d], x)
     end
     return J
 end
-jacobian(fdm, f, x::AV{<:Real}) = jacobian(fdm, f, x, length(f(x)))
+jacobian(fdm, f, x::Vector{<:Real}) = jacobian(fdm, f, x, length(f(x)))
 
 """
     jvp(fdm, f, x::AbstractVector{<:Real}, ẋ::AbstractVector{<:Real})
 
 Convenience function to compute `jacobian(f, x) * ẋ`.
 """
-jvp(fdm, f, x::AV{<:Real}, ẋ::AV{<:Real}) = jacobian(fdm, f, x) * ẋ
+jvp(fdm, f, x::Vector{<:Real}, ẋ::AV{<:Real}) = jacobian(fdm, f, x) * ẋ
 
 """
     j′vp(fdm, f, ȳ::AbstractVector{<:Real}, x::AbstractVector{<:Real})
 
 Convenience function to compute `jacobian(f, x)' * ȳ`.
 """
-j′vp(fdm, f, ȳ::AV{<:Real}, x::AV{<:Real}) = jacobian(fdm, f, x, length(ȳ))' * ȳ
+j′vp(fdm, f, ȳ::AV{<:Real}, x::Vector{<:Real}) = jacobian(fdm, f, x, length(ȳ))' * ȳ

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -1,9 +1,10 @@
 using FDM: grad, jacobian, jvp, j′vp
 
 @testset "grad" begin
-    x = randn(MersenneTwister(123456), 2)
+    rng, fdm = MersenneTwister(123456), central_fdm(5, 1)
+    x = randn(rng, 2)
     xc = copy(x)
-    @test grad(central_fdm(5, 1), x->sin(x[1]) + cos(x[2]), x) ≈ [cos(x[1]), -sin(x[2])]
+    @test grad(fdm, x->sin(x[1]) + cos(x[2]), x) ≈ [cos(x[1]), -sin(x[2])]
     @test xc == x
 end
 


### PR DESCRIPTION
`similar` is only guaranteed to do sensible things for `Arrays`, as opposed to any arbitrary `AbstractArray`. Consequently, I propose constrained the types of the arrays involved in `gradient` / `jacobian` / `jvp` / `j′vp` to reflect this.

This problem actually caught me out when working with `BlockArrays`. `similar(block_vector)` produces a `BlockVector` whose indices are undefined because the memory for the data isn't allocated, which caused some undefined reference issues.

@wesselb @ararslan what are your thoughts on this?