### PR TITLE
Add to_vec for Adjoint and Transpose

### DIFF
--- a/src/grad.jl
+++ b/src/grad.jl
@@ -94,6 +94,11 @@ end
 to_vec(x::Symmetric) = vec(Matrix(x)), x_vec->Symmetric(reshape(x_vec, size(x)))
 to_vec(X::Diagonal) = vec(Matrix(X)), x_vec->Diagonal(reshape(x_vec, size(X)...))
 
+function to_vec(X::T) where T<:Union{Adjoint,Transpose}
+    U = T.name.wrapper
+    return vec(Matrix(X)), x_vec->U(permutedims(reshape(x_vec, size(X))))
+end
+
 # Non-array data structures.
 function to_vec(x::Tuple)
     x_vecs, x_backs = zip(map(to_vec, x)...)

--- a/test/grad.jl
+++ b/test/grad.jl
@@ -48,6 +48,12 @@ using FDM: grad, jacobian, _jvp, _j′vp, jvp, j′vp, to_vec
         test_to_vec(Symmetric(randn(11, 11)))
         test_to_vec(Diagonal(randn(7)))
 
+        @testset "$T" for T in (Adjoint, Transpose)
+            test_to_vec(T(randn(4, 4)))
+            test_to_vec(T(randn(6)))
+            test_to_vec(T(randn(2, 5)))
+        end
+
         @testset "Tuples" begin
             test_to_vec((5, 4))
             test_to_vec((5, randn(5)))


### PR DESCRIPTION
Currently `to_vec` fails for inputs wrapped in these types, so this adds a method that handles them.