### PR TITLE
Add adaptive function bound computation

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -1,5 +1,88 @@
 export FDMReport, fdm, backward_fdm, forward_fdm, central_fdm
 
+forward_grid(p::Int) = 0:(p - 1)
+backward_grid(p::Int) = (1 - p):0
+function central_grid(p::Int)
+    if isodd(p)
+        return div(1 - p, 2):div(p - 1, 2)
+    else
+        return vcat(div(-p, 2):-1, 1:div(p, 2))
+    end
+end
+
+abstract type FDMethod end
+
+for D in (:Forward, :Backward, :Central)
+    gridf = Symbol(lowercase(String(D)), "_grid")
+    @eval begin
+        struct $D{G<:AbstractVector, C<:AbstractVector} <: FDMethod
+            p::Int
+            q::Int
+            grid::G
+            coefs::C
+        end
+        function $D(p::Integer, q::Integer)
+            q < p || throw(ArgumentError("order of the method must be strictly greater " *
+                                         "than that of the derivative"))
+            # Check whether the method can be computed. We require the factorial of the
+            # method order to be computable with regular `Int`s, but `factorial` will overflow
+            # after 20, so 20 is the largest we can allow.
+            p > 20 && throw(ArgumentError("order of the method is too large to be computed"))
+
+            grid = $gridf(p)
+
+            C = [g^i for i in 0:(p - 1), g in grid]
+            x = zeros(Int, p)
+            x[q + 1] = factorial(q)
+            coefs = C \ x
+
+            return $D{typeof(grid), typeof(coefs)}(p, q, grid, coefs)
+        end
+        (d::$D)(f, x; kwargs...) = fdm(d, f, x; kwargs...)
+    end
+end
+
+maxabs(x) = maximum(abs, x)
+
+function fdm(
+    m::M,
+    f,
+    x;
+    bound=maxabs(f(x)),
+    eps=Base.eps(bound),
+    adapt=1,
+    report=false,
+) where M<:FDMethod
+    p = m.p
+    q = m.q
+    grid = m.grid
+    coefs = m.coefs
+
+    # Adaptively compute the bound on the function and derivative values, if applicable.
+    if 0 < adapt < p
+        newm = (M.name.wrapper)(p + 1, q)
+        dfdx, = fdm(newm, f, x; eps=eps, bound=bound, adapt=(adapt - 1))
+        bound = maxabs(dfdx)
+    end
+
+    # Set the step size by minimising an upper bound on the error of the estimate.
+    C₁ = eps * sum(abs, coefs)
+    C₂ = bound * sum(n->abs(coefs[n] * grid[n]^p), eachindex(coefs)) / factorial(p)
+    ĥ = (q / (p - q) * C₁ / C₂) ^ (1 / p)
+
+    # Estimate the accuracy of the method.
+    accuracy = ĥ^(-q) * C₁ + ĥ^(p - q) * C₂
+
+    # Estimate the value of the derivative.
+    dfdx = sum(i->coefs[i] * f(x + ĥ * grid[i]), eachindex(grid)) / ĥ^q
+
+    if report
+        return dfdx, FDMReport(p, q, grid, coefs, eps, bound, ĥ, accuracy)
+    else
+        return dfdx
+    end
+end
+
 """
     FDMReport
 

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -233,7 +233,16 @@ function fdm(
     # Adaptively compute the bound on the function and derivative values, if applicable.
     if adapt > 0
         newm = (M.name.wrapper)(p + 1, p)
-        dfdx = fdm(newm, f, x; condition=condition, eps=eps, bound=bound, adapt=(adapt - 1))
+        dfdx = fdm(
+            newm,
+            f,
+            x;
+            condition=condition,
+            eps=eps,
+            bound=bound,
+            max_step=max_step,
+            adapt=(adapt - 1),
+        )
         bound = _estimate_bound(dfdx, condition)
     end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,47 +1,59 @@
-using FDM: Forward, Backward, Central
+using FDM: Forward, Backward, Central, Nonstandard
 
 @testset "Methods" begin
     for f in [:forward_fdm, :backward_fdm, :central_fdm]
-        @eval @test $f(10, 1; M=1)(sin, 1) ≈ cos(1)
-        @eval @test $f(10, 2; M=1)(sin, 1) ≈ -sin(1)
+        @eval @test $f(10, 1; bound=1)(sin, 1) ≈ cos(1)
+        @eval @test $f(10, 2; bound=1)(sin, 1) ≈ -sin(1)
 
-        @eval @test $f(10, 1; M=1)(exp, 1) ≈ exp(1)
-        @eval @test $f(10, 2; M=1)(exp, 1) ≈ exp(1)
+        @eval @test $f(10, 1; bound=1)(exp, 1) ≈ exp(1)
+        @eval @test $f(10, 2; bound=1)(exp, 1) ≈ exp(1)
 
-        @eval @test $f(10, 1; M=1)(abs2, 1) ≈ 2
-        @eval @test $f(10, 2; M=1)(abs2, 1) ≈ 2
+        @eval @test $f(10, 1; bound=1)(abs2, 1) ≈ 2
+        @eval @test $f(10, 2; bound=1)(abs2, 1) ≈ 2
 
-        @eval @test $f(10, 1; M=1)(sqrt, 1) ≈ .5
-        @eval @test $f(10, 2; M=1)(sqrt, 1) ≈ -.25
+        @eval @test $f(10, 1; bound=1)(sqrt, 1) ≈ .5
+        @eval @test $f(10, 2; bound=1)(sqrt, 1) ≈ -.25
     end
 
-    @test_throws ArgumentError central_fdm(100, 1)
+    @testset "Adaptation improves estimate" begin
+        @test forward_fdm(5, 1)(log, 0.001; adapt=0) ≈ 969.2571703
+        @test forward_fdm(5, 1)(log, 0.001; adapt=1) ≈ 1000
+    end
 
-    # Test that printing an instance of `FDMReport` contains the information that it should
-    # contain.
-    buffer = IOBuffer()
-    show(buffer, central_fdm(2, 1, Val(true))[2])
-    report = String(take!(copy(buffer)))
-    regex_float = r"[\d\.\+-e]+"
-    regex_array = r"\[([\d.+-e]+(, )?)+\]"
-    @test occursin(Regex(join(map(x -> x.pattern,
-        [
-            r"FDMReport:",
-            r"order of method:", r"\d+",
-            r"order of derivative:", r"\d+",
-            r"grid:", regex_array,
-            r"coefficients:", regex_array,
-            r"roundoff error:", regex_float,
-            r"bounds on derivatives:", regex_float,
-            r"step size:", regex_float,
-            r"accuracy:", regex_float,
-            r""
-        ]
-    ), r"\s*".pattern)), report)
+    @testset "Printing FDMethods" begin
+        @test sprint(show, central_fdm(2, 1)) == """
+            FDMethod:
+              order of method:       2
+              order of derivative:   1
+              grid:                  [-1, 1]
+              coefficients:          [-0.5, 0.5]
+            """
+        m, _ = fdm(central_fdm(2, 1), sin, 1, Val(true))
+        report = sprint(show, m)
+        regex_float = r"[\d\.\+-e]+"
+        regex_array = r"\[([\d.+-e]+(, )?)+\]"
+        @test occursin(Regex(join(map(x -> x.pattern,
+            [
+                r"FDMethod:",
+                r"order of method:", r"\d+",
+                r"order of derivative:", r"\d+",
+                r"grid:", regex_array,
+                r"coefficients:", regex_array,
+                r"roundoff error:", regex_float,
+                r"bounds on derivatives:", regex_float,
+                r"step size:", regex_float,
+                r"accuracy:", regex_float,
+                r""
+            ]
+        ), r"\s*".pattern)), report)
+    end
 
-    @testset "Error conditions" begin
-        @test_throws ArgumentError fdm([1,2,3], 4)
-        @test_throws ArgumentError fdm(zeros(40), 5)
+    @testset "Breaking deprecations" begin
+        @test_throws ErrorException fdm([1,2,3], 4)  # Custom grids need Nonstandard
+        for f in (forward_fdm, backward_fdm, central_fdm)
+            @test_throws ErrorException f(2, 1; M=1)  # Old kwarg, now misplaced
+            @test_throws ErrorException f(2, 1, Val(true))  # Ask fdm for reports instead
+        end
     end
 
     @testset "Types" begin
@@ -52,6 +64,10 @@ using FDM: Forward, Backward, Central
             @test_throws ArgumentError T(5, 1)(sin, 1; adapt=200)
             @test_throws ArgumentError T(5, 1)(sin, 1; eps=0.0)
             @test_throws ArgumentError T(5, 1)(sin, 1; bound=0.0)
+        end
+        @testset "Nonstandard" begin
+            @test Nonstandard([-2, -1, 1], 1)(sin, 1) ≈ cos(1)
+            @test_throws ArgumentError Nonstandard([-2, -1, 1], 1)(sin, 1; adapt=2)
         end
     end
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -20,6 +20,11 @@ using FDM: Forward, Backward, Central, Nonstandard
         @test forward_fdm(5, 1)(log, 0.001; adapt=1) ≈ 1000
     end
 
+    @testset "Limiting step size" begin
+        @test !isfinite(central_fdm(5, 1)(abs, 0.001; max_step=0))
+        @test central_fdm(5, 1)(abs, 0.001) ≈ 1.0
+    end
+
     @testset "Printing FDMethods" begin
         @test sprint(show, central_fdm(2, 1)) == """
             FDMethod:

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,3 +1,5 @@
+using FDM: Forward, Backward, Central
+
 @testset "Methods" begin
     for f in [:forward_fdm, :backward_fdm, :central_fdm]
         @eval @test $f(10, 1; M=1)(sin, 1) ≈ cos(1)
@@ -40,5 +42,13 @@
     @testset "Error conditions" begin
         @test_throws ArgumentError fdm([1,2,3], 4)
         @test_throws ArgumentError fdm(zeros(40), 5)
+    end
+
+    @testset "Types" begin
+        @testset "$T" for T in (Forward, Backward, Central)
+            @test T(5, 1)(sin, 1; adapt=4) ≈ cos(1)
+            @test_throws ArgumentError T(3, 4)
+            @test_throws ArgumentError T(40, 5)
+        end
     end
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -49,6 +49,9 @@ using FDM: Forward, Backward, Central
             @test T(5, 1)(sin, 1; adapt=4) ≈ cos(1)
             @test_throws ArgumentError T(3, 4)
             @test_throws ArgumentError T(40, 5)
+            @test_throws ArgumentError T(5, 1)(sin, 1; adapt=200)
+            @test_throws ArgumentError T(5, 1)(sin, 1; eps=0.0)
+            @test_throws ArgumentError T(5, 1)(sin, 1; bound=0.0)
         end
     end
 end


### PR DESCRIPTION
This introduces a type-based approach that works slightly differently than the current API. Upon construction of a `FDMethod` subtype, the order of the method and the order of the derivative are checked for agreement, and the grid and coefficients are computed and stored. Instances of the types are callable, and doing so produces the value of the derivative. It works recursively when adaptively computing the bound, which results in a better step size and thus a (hopefully) more robust estimate of the derivative.

"Why types?" you may be asking. It just seemed like an efficient way of expressing things and storing intermediate values.

"Where did this adaptive thing come from?" From none other than Wessel himself: https://github.com/wesselb/fdm.