### PR TITLE
Fix issue with tuples

### DIFF
--- a/src/grad.jl
+++ b/src/grad.jl
@@ -104,6 +104,6 @@ function to_vec(x::Tuple)
     x_vecs, x_backs = zip(map(to_vec, x)...)
     sz = cumsum([map(length, x_vecs)...])
     return vcat(x_vecs...), function(v)
-        return ntuple(n->x_backs[n](v[sz[n]-length(x[n])+1:sz[n]]), length(x))
+        return ntuple(n->x_backs[n](v[sz[n]-length(x_vecs[n])+1:sz[n]]), length(x))
     end
 end


### PR DESCRIPTION
Supercedes #14 . Fixes a bug in which the length of the vectorised object should be used, rather than the length of the original object, when these lengths are not equal.