### PR TITLE
Set version to 0.6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FDM"
 uuid = "e25cca7e-83ef-51fa-be6c-dfe2a3123128"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
Required to register the v0.6.1 tag. @wesselb, we should probably delete the existing v0.6.1 tag then after this is merged, use Registrator and TagBot to have the tag done automatically.